### PR TITLE
Add build system configuration to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,11 @@ version = "0.1.0"
 description = ""
 readme = "README.md"
 requires-python = ">=3.12"
+
+[build-system]
+requires = ["setuptools>=78.1.1", "wheel"]
+build-backend = "setuptools.build_meta"
+
 dependencies = [
     "albumentations>=2.0.5",
     "cmake>=4.0.0",


### PR DESCRIPTION
- Added [build-system] section to pyproject.toml for specifying build requirements.
- Included setuptools and wheel as required packages for building the project.